### PR TITLE
ISSUE-0 - Add missing dependency for CustomizablePlayerModels

### DIFF
--- a/patches/babric.json
+++ b/patches/babric.json
@@ -45,6 +45,9 @@
         },
         {
             "name": "commons-codec:commons-codec:1.15"
+        },
+        {
+            "name": "com.google.guava:failureaccess:1.0.1"
         }
     ]
 }

--- a/patches/net.fabricmc.fabric-loader.json
+++ b/patches/net.fabricmc.fabric-loader.json
@@ -26,7 +26,7 @@
             "url": "https://maven.fabricmc.net/"
         },
         {
-            "name": "babric:fabric-loader:0.15.6-babric.2",
+            "name": "babric:fabric-loader:0.15.6-babric.1",
             "url": "https://maven.glass-launcher.net/babric/"
         }
     ],

--- a/patches/net.fabricmc.fabric-loader.json
+++ b/patches/net.fabricmc.fabric-loader.json
@@ -26,7 +26,7 @@
             "url": "https://maven.fabricmc.net/"
         },
         {
-            "name": "babric:fabric-loader:0.15.6-babric.1",
+            "name": "babric:fabric-loader:0.15.6-babric.2",
             "url": "https://maven.glass-launcher.net/babric/"
         }
     ],
@@ -39,5 +39,5 @@
     ],
     "type": "release",
     "uid": "net.fabricmc.fabric-loader",
-    "version": "0.15.6-babric.1"
+    "version": "0.15.6-babric.2"
 }

--- a/patches/net.fabricmc.fabric-loader.json
+++ b/patches/net.fabricmc.fabric-loader.json
@@ -39,5 +39,5 @@
     ],
     "type": "release",
     "uid": "net.fabricmc.fabric-loader",
-    "version": "0.15.6-babric.2"
+    "version": "0.15.6-babric.1"
 }


### PR DESCRIPTION
tom5454 — Today at 7:06 PM

The prism instance is missing com.google.guava:failureaccess:1.0.1 library. This is a dependency for Guava's Cache classes that's heavily used inside CPM.
I added this to the libraries list:
```
{
    "downloads": {
        "artifact": {
            "path": "com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar",
            "sha1": "1dcf1de382a0bf95a3d8b0849546c88bac1292c9",
            "size": 4617,
            "url": "https://libraries.minecraft.net/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar"
        }
    },
    "name": "com.google.guava:failureaccess:1.0.1"
}
```
The development environment for Babric has this installed, it's only missing in the Prism instance.