### PR TITLE
Improve Java 17 DPI scaling compatibility

### DIFF
--- a/instance.cfg
+++ b/instance.cfg
@@ -1,5 +1,5 @@
 InstanceType=OneSix
-JvmArgs="-Dapple.awt.application.appearance=system"
+JvmArgs="-Duser.language=en -Dapple.awt.application.appearance=system -Dsun.java2d.uiScale=1 -Dhttp.proxyHost=betacraft.uk -Dhttp.proxyPort=11705 -XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump"
 OverrideJavaArgs=true
 name=babric b1.7.3
 iconKey=fabric

--- a/instance.cfg
+++ b/instance.cfg
@@ -1,5 +1,5 @@
 InstanceType=OneSix
-JvmArgs="-Duser.language=en -Dapple.awt.application.appearance=system -Dsun.java2d.uiScale=1 -Dhttp.proxyHost=betacraft.uk -Dhttp.proxyPort=11705 -XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump"
+JvmArgs="-Dapple.awt.application.appearance=system -Dsun.java2d.uiScale=1"
 OverrideJavaArgs=true
 name=babric b1.7.3
 iconKey=fabric


### PR DESCRIPTION
### Summary

Updates the default JVM arguments to improve compatibility when running the Beta 1.7.3 Babric instance on newer Java runtimes.

### Motivation

Some modded Beta 1.7.3 setups, including StationAPI-based setups, require Java 17+. When running old Minecraft/LWJGL 2 on newer Java versions, Java DPI scaling can cause the game canvas to render at the wrong size inside the window on some systems.

### Changes

- Adds `-Dsun.java2d.uiScale=1` to force Java UI scaling to 1x and reduce DPI/canvas sizing mismatches.
- Keeps `-Dapple.awt.application.appearance=system` for macOS AWT system appearance compatibility.
- Keeps the Betacraft HTTP proxy arguments for legacy Beta-era service compatibility:
  - `-Dhttp.proxyHost=betacraft.uk`
  - `-Dhttp.proxyPort=11705`
- Keeps the existing heap dump path argument for crash/debug diagnostics.

### Testing

Tested with Prism Launcher 11.0.2 on Windows 11 using Eclipse Adoptium Java 17.0.19. The Babric Beta 1.7.3 instance launched successfully with StationAPI enabled.
<img width="572" height="340" alt="{13024DB7-736B-49E7-91B8-3B9CD4A7746C}" src="https://github.com/user-attachments/assets/ff1a1bbf-422a-4a27-b8ad-bb77eefa9c9a" />

<img width="573" height="352" alt="{F380671D-5E64-4113-9635-77C5F7335E63}" src="https://github.com/user-attachments/assets/d0003b75-2ec6-4c68-a1ff-7d5337431759" />